### PR TITLE
refactor(extension): address PR #40 review feedback

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -19,13 +19,23 @@ jobs:
 
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
 
     - name: Cache cargo
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: extension
 
+    - name: cargo fmt
+      working-directory: extension
+      run: cargo fmt --all -- --check
+
+    - name: cargo clippy
+      working-directory: extension
+      run: cargo clippy --locked --all-targets -- -D warnings
+
     # ubuntu-latest has Docker pre-installed; testcontainers picks it up.
-    - name: Run cargo test
+    - name: cargo test
       working-directory: extension
       run: cargo test --locked

--- a/extension/Cargo.lock
+++ b/extension/Cargo.lock
@@ -38,8 +38,6 @@ dependencies = [
  "link_args",
  "log",
  "seq-macro",
- "serde",
- "serde_json",
  "state",
  "uuid",
  "winapi",
@@ -1446,9 +1444,6 @@ dependencies = [
  "bytes",
  "fallible-iterator",
  "postgres-protocol",
- "serde_core",
- "serde_json",
- "uuid",
 ]
 
 [[package]]
@@ -1946,13 +1941,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 name = "skua"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arma-rs",
  "deadpool-postgres",
- "futures",
  "regex",
- "serde",
- "serde_json",
  "testcontainers-modules",
  "tokio",
  "tokio-postgres",
@@ -2205,7 +2196,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2521,7 +2511,6 @@ checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
- "serde_core",
  "wasm-bindgen",
 ]
 

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -8,18 +8,14 @@ name = "skua"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-arma-rs = { version = "1.12.1", features = ["serde", "serde_json", "uuid"] }
-uuid = { version = "1.19.0", features = ["serde", "v7"] }
+arma-rs = { version = "1.12.1", features = ["uuid"] }
+uuid = { version = "1.19.0", features = ["v7"] }
 deadpool-postgres = { version = "0.14.1" }
-tokio-postgres = { version = "0.7.15", features = ["with-serde_json-1", "with-uuid-1"] }
-tokio = { version = "1.49.0", features = ["full"] }
+tokio-postgres = { version = "0.7.15" }
+tokio = { version = "1.49.0", features = ["rt-multi-thread", "macros", "sync", "time", "net", "io-util"] }
 regex = "1.12.2"
-anyhow = "1.0.100"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
-serde = "1.0.228"
-serde_json = "1.0.149"
-futures = "0.3.31"
 
 [dev-dependencies]
 testcontainers-modules = { version = "0.14", features = ["postgres"] }

--- a/extension/src/database/pool.rs
+++ b/extension/src/database/pool.rs
@@ -4,13 +4,19 @@ use deadpool_postgres::{Manager, Pool};
 use std::env;
 use tokio::sync::OnceCell;
 use tokio_postgres::{Config, NoTls};
-use tracing::info;
+use tracing::debug;
 
 use super::state::{AtomicDatabaseState, DatabaseState};
 use crate::error::DbError;
 
 /// Global lazy-initialized database instance.
 static DATABASE: OnceCell<Database> = OnceCell::const_new();
+
+/// Pre-init state observable before `DATABASE` is populated. Set to `Failed`
+/// when `init_from_env` errors so [`get_state`] can report a terminal failure
+/// even though `OnceCell` itself stays empty (and will retry on the next call).
+pub(super) static INIT_STATE: AtomicDatabaseState =
+    AtomicDatabaseState::new(DatabaseState::AwaitConnect);
 
 pub struct Database {
     pool: Pool,
@@ -22,16 +28,16 @@ impl Database {
         let mut cfg = Config::new();
 
         // 127.0.0.1 not "localhost": Proton may not resolve localhost.
-        cfg.host(&env::var("DATABASE_HOST").unwrap_or_else(|_| "127.0.0.1".into()));
+        cfg.host(env::var("DATABASE_HOST").unwrap_or_else(|_| "127.0.0.1".into()));
         cfg.port(
             env::var("DATABASE_PORT")
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(55432),
         );
-        cfg.user(&env::var("DATABASE_USER").unwrap_or_else(|_| "postgres".into()));
-        cfg.password(&env::var("DATABASE_PASSWORD").unwrap_or_else(|_| "changeit".into()));
-        cfg.dbname(&env::var("DATABASE_NAME").unwrap_or_else(|_| "postgres".into()));
+        cfg.user(env::var("DATABASE_USER").unwrap_or_else(|_| "postgres".into()));
+        cfg.password(env::var("DATABASE_PASSWORD").unwrap_or_else(|_| "changeit".into()));
+        cfg.dbname(env::var("DATABASE_NAME").unwrap_or_else(|_| "postgres".into()));
 
         let pool_size = env::var("DATABASE_POOL_SIZE")
             .ok()
@@ -75,7 +81,13 @@ impl Database {
 }
 
 pub async fn get_db() -> Result<&'static Database, tokio_postgres::Error> {
-    DATABASE.get_or_try_init(Database::init_from_env).await
+    match DATABASE.get_or_try_init(Database::init_from_env).await {
+        Ok(db) => Ok(db),
+        Err(e) => {
+            INIT_STATE.store(DatabaseState::Failed);
+            Err(e)
+        }
+    }
 }
 
 pub async fn get_client() -> Result<deadpool_postgres::Client, DbError> {
@@ -84,16 +96,15 @@ pub async fn get_client() -> Result<deadpool_postgres::Client, DbError> {
 }
 
 pub fn get_state() -> DatabaseState {
-    DATABASE
-        .get()
-        .map(|db| db.state())
-        .unwrap_or(DatabaseState::AwaitConnect)
+    match DATABASE.get() {
+        Some(db) => db.state(),
+        None => INIT_STATE.load(),
+    }
 }
 
 /// Arma-callable: returns the current database state.
 pub fn get_database_state() -> DatabaseState {
-    info!("Database state requested");
     let state = get_state();
-    info!(?state, "Database state returned");
+    debug!(?state, "database state requested");
     state
 }

--- a/extension/src/database/schema.rs
+++ b/extension/src/database/schema.rs
@@ -1,69 +1,63 @@
 //! Database schema bootstrap operations.
 
+use std::sync::LazyLock;
+
 use arma_rs::Context;
 use regex::Regex;
 use tokio_postgres::Client;
 use tracing::{info, instrument};
 
-use super::pool::get_db;
+use super::pool::{INIT_STATE, get_db};
 use super::sql::{campaign, master};
 use super::state::DatabaseState;
 use crate::core::RUNTIME;
 use crate::error::{QueryResult, QueryState, transient_error};
 
+static CAMPAIGN_KEY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-z0-9_]{3,49}$").unwrap());
+
 /// Sanitizes a key for use as a schema name. Errors if the key doesn't match
 /// `^[a-z0-9_]{3,49}$` (after lowercasing and replacing `-`/space with `_`).
 pub fn sanitize_key(key: &str) -> Result<String, &'static str> {
-    let key = key.replace('-', "_").replace(' ', "_").to_lowercase();
+    let key = key.replace(['-', ' '], "_").to_lowercase();
 
-    let re = Regex::new(r"^[a-z0-9_]{3,49}$").unwrap();
-    if !re.is_match(&key) {
+    if !CAMPAIGN_KEY_RE.is_match(&key) {
         return Err("invalid key pattern");
     }
 
     Ok(key)
 }
 
+/// Translates the raw `campaign_id` Arma argument into the optional sanitized
+/// key the bootstrap pipeline expects. Empty input means "master only";
+/// non-empty input is validated through [`sanitize_key`].
+pub(super) fn parse_campaign_arg(raw: &str) -> Result<Option<String>, &'static str> {
+    if raw.is_empty() {
+        Ok(None)
+    } else {
+        sanitize_key(raw).map(Some)
+    }
+}
+
 #[instrument(level = "debug", name = "bootstrap_master", skip(client))]
 pub(super) async fn bootstrap_master(client: &Client) -> Result<(), QueryResult> {
-    if let Err(e) = client.execute(master::SCHEMA, &[]).await {
-        return Err(transient_error("Failed to create master schema", e));
-    }
-
-    let layer1 = [
+    // Order matters: each entry depends on (at most) those above it
+    // (schema → base tables → tables with FKs → indexes).
+    let statements: &[(&str, &str)] = &[
+        (master::SCHEMA, "master schema"),
         (master::RANKS, "ranks table"),
         (master::CERTIFICATIONS, "certifications table"),
         (master::CAMPAIGNS, "campaigns table"),
-    ];
-
-    for (sql, desc) in layer1 {
-        if let Err(e) = client.execute(sql, &[]).await {
-            return Err(transient_error(&format!("Failed to create {}", desc), e));
-        }
-    }
-
-    if let Err(e) = client.execute(master::PLAYER_INFO, &[]).await {
-        return Err(transient_error("Failed to create player_info table", e));
-    }
-
-    for (sql, desc) in [
+        (master::PLAYER_INFO, "player_info table"),
         (master::PLAYER_INFO_IDX_ADMIN, "admin index"),
         (master::PLAYER_INFO_IDX_BANNED, "banned index"),
-    ] {
-        if let Err(e) = client.execute(sql, &[]).await {
-            return Err(transient_error(&format!("Failed to create {}", desc), e));
-        }
-    }
-
-    if let Err(e) = client.execute(master::PLAYER_CERTS, &[]).await {
-        return Err(transient_error("Failed to create player_certs table", e));
-    }
-
-    for (sql, desc) in [
+        (master::PLAYER_CERTS, "player_certs table"),
         (master::PLAYER_CERTS_IDX_STEAM, "player_certs steam index"),
         (master::PLAYER_CERTS_IDX_CERT, "player_certs cert index"),
-    ] {
-        if let Err(e) = client.execute(sql, &[]).await {
+    ];
+
+    for (sql, desc) in statements {
+        if let Err(e) = client.execute(*sql, &[]).await {
             return Err(transient_error(&format!("Failed to create {}", desc), e));
         }
     }
@@ -73,30 +67,21 @@ pub(super) async fn bootstrap_master(client: &Client) -> Result<(), QueryResult>
 }
 
 #[instrument(level = "debug", name = "bootstrap_campaign", skip(client))]
-pub(super) async fn bootstrap_campaign(client: &Client, campaign_id: &str) -> Result<(), QueryResult> {
-    let schema_key = campaign_id.replace('-', "_");
-
-    let sql = campaign::SCHEMA.replace("${campaign_id}", &schema_key);
-    if let Err(e) = client.execute(&sql, &[]).await {
-        return Err(transient_error("Failed to create campaign schema", e));
-    }
-
-    for (template, desc) in [
+pub(super) async fn bootstrap_campaign(
+    client: &Client,
+    campaign_id: &str,
+) -> Result<(), QueryResult> {
+    let statements: &[(&str, &str)] = &[
+        (campaign::SCHEMA, "campaign schema"),
         (campaign::PLAYER_DATA, "player_data table"),
         (campaign::PLAYER_WORLD_DATA, "player_world_data table"),
         (campaign::WORLD_DATA, "world_data table"),
-    ] {
-        let sql = template.replace("${campaign_id}", &schema_key);
-        if let Err(e) = client.execute(&sql, &[]).await {
-            return Err(transient_error(&format!("Failed to create {}", desc), e));
-        }
-    }
-
-    for (template, desc) in [
         (campaign::PLAYER_WORLD_DATA_IDX, "player_world_data index"),
         (campaign::WORLD_DATA_IDX, "world_data index"),
-    ] {
-        let sql = template.replace("${campaign_id}", &schema_key);
+    ];
+
+    for (template, desc) in statements {
+        let sql = template.replace("${campaign_id}", campaign_id);
         if let Err(e) = client.execute(&sql, &[]).await {
             return Err(transient_error(&format!("Failed to create {}", desc), e));
         }
@@ -107,7 +92,7 @@ pub(super) async fn bootstrap_campaign(client: &Client, campaign_id: &str) -> Re
         VALUES ($1)
         ON CONFLICT (campaign_id) DO NOTHING
     "#;
-    let campaign_id_formatted = format!("skua_campaign_{}", schema_key);
+    let campaign_id_formatted = format!("skua_campaign_{}", campaign_id);
     if let Err(e) = client
         .execute(register_sql, &[&campaign_id_formatted])
         .await
@@ -123,7 +108,12 @@ pub(super) async fn bootstrap_campaign(client: &Client, campaign_id: &str) -> Re
 pub(super) async fn do_bootstrap(campaign_id: Option<String>) -> QueryResult {
     let db = match get_db().await {
         Ok(db) => db,
-        Err(e) => return transient_error("Failed to get database handle", e),
+        Err(e) => {
+            // Sticky terminal failure: OnceCell will retry on the next get_db()
+            // call, but get_state() reports Failed in the meantime.
+            INIT_STATE.store(DatabaseState::Failed);
+            return transient_error("Failed to get database handle", e);
+        }
     };
 
     let client = match db.get_conn().await {
@@ -135,10 +125,10 @@ pub(super) async fn do_bootstrap(campaign_id: Option<String>) -> QueryResult {
         return result;
     }
 
-    if let Some(ref cid) = campaign_id {
-        if let Err(result) = bootstrap_campaign(&client, cid).await {
-            return result;
-        }
+    if let Some(ref cid) = campaign_id
+        && let Err(result) = bootstrap_campaign(&client, cid).await
+    {
+        return result;
     }
 
     db.set_state(DatabaseState::ConnectedInit);
@@ -151,13 +141,9 @@ pub(super) async fn do_bootstrap(campaign_id: Option<String>) -> QueryResult {
 /// Arma-callable entry point. Spawns the bootstrap onto the global runtime and
 /// returns `Processing`; result is delivered via `skua:database` callback.
 pub fn bootstrap(ctx: Context, campaign_id: String) -> QueryState {
-    let campaign = if campaign_id.is_empty() {
-        None
-    } else {
-        match sanitize_key(&campaign_id) {
-            Ok(sanitized) => Some(sanitized),
-            Err(_) => return QueryState::InvalidArgument,
-        }
+    let campaign = match parse_campaign_arg(&campaign_id) {
+        Ok(c) => c,
+        Err(_) => return QueryState::InvalidArgument,
     };
 
     RUNTIME.spawn(async move {

--- a/extension/src/database/state.rs
+++ b/extension/src/database/state.rs
@@ -58,7 +58,7 @@ pub struct AtomicDatabaseState {
 }
 
 impl AtomicDatabaseState {
-    pub fn new(state: DatabaseState) -> Self {
+    pub const fn new(state: DatabaseState) -> Self {
         Self {
             inner: AtomicU8::new(state as u8),
         }
@@ -69,7 +69,8 @@ impl AtomicDatabaseState {
             0 => DatabaseState::AwaitConnect,
             1 => DatabaseState::ConnectedInit,
             2 => DatabaseState::ConnectedAwaitInit,
-            _ => DatabaseState::Failed,
+            3 => DatabaseState::Failed,
+            n => unreachable!("invalid DatabaseState repr {n}"),
         }
     }
 

--- a/extension/src/database/tests.rs
+++ b/extension/src/database/tests.rs
@@ -2,7 +2,70 @@
 //!
 //! Integration tests exercise the bootstrap logic against a real Postgres
 //! instance via testcontainers, so they require Docker. Unit tests (sync
-//! check, sanitize_key) have no external dependencies.
+//! check, sanitize_key, parse_campaign_arg, arma roundtrip) have no external
+//! dependencies.
+
+#[cfg(test)]
+mod arg_parsing {
+    use super::super::schema::parse_campaign_arg;
+
+    #[test]
+    fn empty_string_means_master_only() {
+        assert_eq!(parse_campaign_arg(""), Ok(None));
+    }
+
+    #[test]
+    fn valid_key_round_trips() {
+        assert_eq!(
+            parse_campaign_arg("valid_key"),
+            Ok(Some("valid_key".to_string()))
+        );
+    }
+
+    #[test]
+    fn dashes_and_spaces_normalize() {
+        assert_eq!(
+            parse_campaign_arg("My-Campaign Name"),
+            Ok(Some("my_campaign_name".to_string()))
+        );
+    }
+
+    #[test]
+    fn invalid_chars_reject() {
+        assert!(parse_campaign_arg("BAD!key").is_err());
+        assert!(parse_campaign_arg("bad/key").is_err());
+    }
+}
+
+#[cfg(test)]
+mod arma_roundtrip {
+    use super::super::state::DatabaseState;
+    use arma_rs::{FromArma, IntoArma, Value};
+
+    fn assert_round_trip(state: DatabaseState, expected_u8: u8) {
+        assert_eq!(state.to_arma(), Value::Number(expected_u8.into()));
+        let parsed = DatabaseState::from_arma(expected_u8.to_string()).expect("from_arma");
+        assert_eq!(parsed, state);
+    }
+
+    #[test]
+    fn all_variants_round_trip() {
+        assert_round_trip(DatabaseState::AwaitConnect, 0);
+        assert_round_trip(DatabaseState::ConnectedInit, 1);
+        assert_round_trip(DatabaseState::ConnectedAwaitInit, 2);
+        assert_round_trip(DatabaseState::Failed, 3);
+    }
+
+    #[test]
+    fn unknown_value_rejected() {
+        assert!(DatabaseState::from_arma("99".into()).is_err());
+    }
+
+    #[test]
+    fn non_numeric_rejected() {
+        assert!(DatabaseState::from_arma("nope".into()).is_err());
+    }
+}
 
 /// Verifies that `addons/main/script_macros_enums.hpp` stays in sync with the
 /// Rust `DatabaseState` enum. If you add/rename/reorder a variant, either run
@@ -142,7 +205,10 @@ mod integration_tests {
 
     #[test]
     fn sanitize_key_lowercases_and_replaces() {
-        assert_eq!(sanitize_key("My-Campaign Name").unwrap(), "my_campaign_name");
+        assert_eq!(
+            sanitize_key("My-Campaign Name").unwrap(),
+            "my_campaign_name"
+        );
     }
 
     #[test]
@@ -257,7 +323,11 @@ mod integration_tests {
             .await
             .expect("Schema query failed")
             .get(0);
-        assert!(schema_exists, "Campaign schema {} should exist", schema_name);
+        assert!(
+            schema_exists,
+            "Campaign schema {} should exist",
+            schema_name
+        );
 
         let expected_tables = ["player_data", "player_world_data", "world_data"];
         for table in expected_tables {

--- a/extension/src/error/query.rs
+++ b/extension/src/error/query.rs
@@ -4,9 +4,8 @@ use std::error::Error;
 use std::fmt::Display;
 
 use arma_rs::{FromArma, IntoArma};
-use serde::Serialize;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum QueryState {
     Processing = 0,
@@ -48,7 +47,7 @@ impl FromArma for QueryState {
     }
 }
 
-#[derive(Debug, IntoArma, FromArma, Serialize)]
+#[derive(Debug, IntoArma, FromArma)]
 pub struct QueryError {
     #[arma(to_string)]
     pub code: String,
@@ -66,7 +65,7 @@ impl Display for QueryError {
 
 impl Error for QueryError {}
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct QueryResult {
     pub state: QueryState,
     pub error: Option<QueryError>,

--- a/extension/src/logging/commands.rs
+++ b/extension/src/logging/commands.rs
@@ -6,21 +6,25 @@ use tracing::Level;
 use super::LOG_LEVEL;
 
 /// Set the log level dynamically. Valid levels: ERROR, WARN, INFO, DEBUG, TRACE.
-pub fn set_level(level: String) -> String {
+///
+/// Returns the new level on success, or an error message describing why the
+/// request was rejected (unknown level, poisoned lock).
+pub fn set_level(level: String) -> Result<String, String> {
     let new_level = match level.to_uppercase().as_str() {
         "ERROR" => Level::ERROR,
         "WARN" => Level::WARN,
         "INFO" => Level::INFO,
         "DEBUG" => Level::DEBUG,
         "TRACE" => Level::TRACE,
-        _ => return String::new(),
+        other => return Err(format!("unknown log level: {}", other)),
     };
 
-    if let Ok(mut current) = LOG_LEVEL.write() {
-        *current = new_level;
-        get_level()
-    } else {
-        String::new()
+    match LOG_LEVEL.write() {
+        Ok(mut current) => {
+            *current = new_level;
+            Ok(get_level())
+        }
+        Err(_) => Err("LOG_LEVEL lock poisoned".into()),
     }
 }
 

--- a/extension/src/logging/layer.rs
+++ b/extension/src/logging/layer.rs
@@ -60,8 +60,22 @@ where
 struct MessageVisitor<'a>(&'a mut String);
 
 impl<'a> tracing::field::Visit for MessageVisitor<'a> {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            *self.0 = value.to_string();
+        } else {
+            if !self.0.is_empty() {
+                self.0.push_str(", ");
+            }
+            self.0.push_str(&format!("{} = {}", field.name(), value));
+        }
+    }
+
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         if field.name() == "message" {
+            // `record_str` already handles plain string messages; this arm
+            // covers non-string `tracing::field::display`/`debug` values used
+            // as the message.
             *self.0 = format!("{:?}", value);
         } else {
             if !self.0.is_empty() {


### PR DESCRIPTION
Stacked on #40. Addresses the review feedback there.

## Summary

- **`refactor(extension): polish + wire Failed from review feedback`** — `LazyLock` the campaign-key regex, drop the redundant `.replace('-', "_")` inside `bootstrap_campaign` (caller already sanitized), flatten `bootstrap_master`/`bootstrap_campaign` into single ordered tables, extract `parse_campaign_arg` so the empty/sanitize/invalid decision is testable without an `arma_rs::Context`. Make `AtomicDatabaseState::new` a `const fn` and replace its silent `_=>Failed` default with `unreachable!()`. Add `INIT_STATE` so `get_state()` can report `Failed` before `OnceCell` is populated; set `Failed` on the `get_db()` / `do_bootstrap` error paths. Demote per-poll state log from `info!` to `debug!`. `MessageVisitor::record_str` for plain string messages (no more `"quoted"` log output). `set_level` returns `Result<String, String>` so callers can tell invalid level from a successful set.
- **`chore(extension): prune unused deps + trim tokio features`** — drop `arma-rs` `serde`/`serde_json` features, `uuid` `serde`, `tokio-postgres` `with-serde_json-1`/`with-uuid-1`, direct `serde`/`serde_json`/`anyhow`/`futures` deps, and `Serialize` derives on `Query*`. Replace `tokio = features = ["full"]` with the narrow set the code actually uses (`rt-multi-thread`, `macros`, `sync`, `time`, `net`, `io-util`). Reintroduce alongside the first caller in phase 2.
- **`ci(extension): require cargo fmt + clippy`** — pull `rustfmt`/`clippy` components and run `cargo fmt --all -- --check` and `cargo clippy --locked --all-targets -- -D warnings` before `cargo test`. Fixes a handful of pre-existing clippy nits in `pool.rs` along the way.
- **`test(extension): parse_campaign_arg + DatabaseState arma roundtrip`** — new `arg_parsing` and `arma_roundtrip` unit modules. The roundtrip module catches variant reorders the enum_sync hpp check alone can't see. Both modules are Docker-free.

`addons/main/script_macros_enums.hpp` is **not** touched — `DatabaseState` variants/order stay the same, so the enum-sync test still passes.

## Test plan

- [x] `cargo build --release`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked` — 17/17 (10 carried + 4 `arg_parsing` + 3 `arma_roundtrip`)
- [ ] Extension CI workflow green on this PR
- [ ] Sanity: deliberate bad `DATABASE_HOST` leaves state at `Failed` (not retry-forever-`AwaitConnect`); `database:state` poll no longer floods the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)